### PR TITLE
CompositeKey: Clear challenge response keys

### DIFF
--- a/src/keys/CompositeKey.cpp
+++ b/src/keys/CompositeKey.cpp
@@ -42,7 +42,9 @@ CompositeKey::~CompositeKey()
 void CompositeKey::clear()
 {
     qDeleteAll(m_keys);
+    qDeleteAll(m_challengeResponseKeys);
     m_keys.clear();
+    m_challengeResponseKeys.clear();
 }
 
 bool CompositeKey::isEmpty() const
@@ -122,6 +124,7 @@ bool CompositeKey::challenge(const QByteArray& seed, QByteArray& result) const
      * maintain backwards compatability with regular databases.
      */
     if (m_challengeResponseKeys.length() == 0) {
+        result.clear();
         return true;
     }
 


### PR DESCRIPTION
* Allow a previously YubiKey protected database to be saved without the YubiKey challenge-response code.
* Thanks to @pgalves for discovering and patching